### PR TITLE
Updated html.md

### DIFF
--- a/src/pages/sheet/html.md
+++ b/src/pages/sheet/html.md
@@ -157,13 +157,13 @@ title: "HTML Cheatsheet"
 
 ## Input Types
 
-|   Field Type    | HTML Code Notes                                         |
+|   Field Type    | HTML Code Notes                                         | Description |
 | :-------------: | ------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 |   plain text    | `<input type="text">`                                   | the type attribute can be omitted                                                            |
 | password field  | `<input type="password">`                               | echoes dots instead of characters                                                            |
 |    text area    | `<textarea></textarea>`                                 | a more customizable plain text area                                                          |
 |    checkbox     | `<input type="checkbox">`                               | can be toggled on or off                                                                     |
-|  radio button   | `<input type="radio">` can be grouped with other inputs |
+|  radio button   | `<input type="radio">` can be grouped with other inputs |                                                                                              |
 | drop-down lists | `<select><option>`                                      | [check here for more info](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) |
 |   file picker   | `<input type="file">`                                   | pops up an “open file” dialog                                                                |
 |  hidden field   | `<input type="hidden">`                                 | nothing there!                                                                               |


### PR DESCRIPTION
input types wasn't rendering correctly due to missing | marks now renders the table correctly

## Change Summary

The input types table wasn't properly rendering due to missing formatting marks.

## Checklist

**If you haven't fulfilled the below requirements or even delete the entire checklist, your PR won't be reviewed and will be closed without notice.**

### General

- [x] This Pull Request is all my own work. (You'll be blacklisted if you are caught for plagiarism.)
- [x] I've read [CONTRIBUTING.md](https://github.com/aryankashyap7/CheatSheets-for-Developers/blob/main/docs/CONTRIBUTING.md)
- [x] I've made some valid changes to the CheatSheet, and they are not just minor changes.

### Changes

- [x] I've read and followed the [Solution Template](https://github.com/aryankashyap7/CheatSheets-for-Developers/blob/main/docs/CONTRIBUTING.md#submission-template)

**Note: To mark the checkbox, put an `x` inside the `[ ]` (like this: `[x]`).**
